### PR TITLE
markdig migration

### DIFF
--- a/IIS-Administration/api/certificates.md
+++ b/IIS-Administration/api/certificates.md
@@ -118,5 +118,4 @@ The certificates API supports filtering certificates by store. To do this, the _
         }
     ]
 }
-
 ```

--- a/IIS-Administration/api/scope.md
+++ b/IIS-Administration/api/scope.md
@@ -6,8 +6,8 @@ uid: api/scope
 
 The IIS configuration system is a hierarchy that extends from the root web server configuration to as far down as individual folders with a web application. The root configuration file is named _applicationHost.config_ and it resides in the IIS installation directory. The rest of a web application's configuration exists in web.config files within the application's directories. One benefit of using web.config files is that application's can introduce configuration at different paths without affecting the web server as a whole. At the same time, it is possible to define configuration in the root _applicationHost.config_ that targets only a specific path inside a specific web application. This means there are two different ways to think of configuration scoping.
 
- 1. Reading/modifying configuration for an arbitrary path of a web application.
- 2. Modifying configuration for a specific path, but placing the configuration in a configuration file at a higher level in the configuration hierarchy.
+1. Reading/modifying configuration for an arbitrary path of a web application.
+2. Modifying configuration for a specific path, but placing the configuration in a configuration file at a higher level in the configuration hierarchy.
    * Example: Modifying a setting for *Default Web Site/MyApp/MyFolder* and placing it in the web.config file located in the root of *Default Web Site*
 
 ## Targeting a Specific Path Within a Web Application

--- a/IIS-Administration/configuration/appsettings.json.md
+++ b/IIS-Administration/configuration/appsettings.json.md
@@ -33,9 +33,9 @@ The following enables CORS for [manage.iis.net](https://manage.iis.net)
 
 __rules__: A set of CORS rules to control how the API shares resources.
 
- * __origin__: The origin, as defined in the [CORS](https://www.w3.org/TR/cors/) specification, to allow or deny. If the wild card character, **&ast;**, is provided as the origin, that rule will apply to all origins.
+* **origin**: The origin, as defined in the [CORS](https://www.w3.org/TR/cors/) specification, to allow or deny. If the wild card character, **&ast;**, is provided as the origin, that rule will apply to all origins.
 
- * __allow__: Indicates whether resources should be shared to the specified origin.
+* __allow__: Indicates whether resources should be shared to the specified origin.
 
 ## Files
 

--- a/IIS-Administration/docfx.json
+++ b/IIS-Administration/docfx.json
@@ -32,6 +32,7 @@
     "globalMetadata": {},
     "fileMetadata": {},
     "template": [],
-    "dest": "_site"
+    "dest": "_site",
+    "markdownEngineName": "markdig"
   }
 }


### PR DESCRIPTION
As part of a OPS-wide move, we're moving away from DocFX flavored markdown to [CommonMark](http://commonmark.org/).

I haven't yet reviewed if everything looks good with the new parser, but I'm opening this PR to track this work.