### PR TITLE
publish swagger.json as resource

### DIFF
--- a/IIS-Administration/docfx.json
+++ b/IIS-Administration/docfx.json
@@ -3,8 +3,7 @@
     "content": [
       {
         "files": [
-          "**/*.md",
-          "**/*swagger.json"
+          "**/*.md"
         ],
         "exclude": [
           "**/obj/**",
@@ -17,7 +16,8 @@
       {
         "files": [
           "**/*.png",
-          "**/*.jpg"
+          "**/*.jpg",
+          "**/*swagger.json"
         ],
         "exclude": [
           "**/obj/**",


### PR DESCRIPTION
The [`iis.administration.swagger.json`](https://github.com/MicrosoftDocs/IIS.Administration-docs/blob/live/IIS-Administration/api/iis.administration.swagger.json) doesn't provide `$schema` in its content, OPS cannot build the file as sdp content.

The pull request is to publish the file as resource file instead.